### PR TITLE
update scripts to pull from wrf-model repo, instead of davegill

### DIFF
--- a/.ci/terraform/make_NEW_sh.csh
+++ b/.ci/terraform/make_NEW_sh.csh
@@ -53,7 +53,7 @@ foreach COUNT ( $TEST_NUM )
 		echo "wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh" >> $name
 		echo "mkdir /home/ubuntu/wrf-stuff" >> $name
 		echo "cd wrf-stuff/" >> $name
-		echo "git clone --branch regression+feature https://github.com/davegill/wrf-coop.git" >> $name
+		echo "git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git" >> $name
 		echo "cd wrf-coop/" >> $name
 		echo 'sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile' >> $name
 		echo "csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop" >> $name

--- a/.ci/terraform/make_ORIG_sh.csh
+++ b/.ci/terraform/make_ORIG_sh.csh
@@ -18,7 +18,7 @@ foreach f ( $TEST_NUM )
 	echo "su - ubuntu << 'EOF'" >> $name
 	echo "mkdir /home/ubuntu/wrf-stuff" >> $name
 	echo "cd wrf-stuff/" >> $name
-	echo "git clone git@github.com:davegill/wrf-coop.git" >> $name
+	echo "git clone git@github.com:wrf-model/wrf-coop.git" >> $name
 	echo "cd wrf-coop/" >> $name
 	echo 'sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile' >> $name
 	echo "csh build.csh /home/ubuntu/wrf-stuff/ /home/ubuntu/wrf-stuff/" >> $name

--- a/.ci/terraform/wrf_testcase_0.sh
+++ b/.ci/terraform/wrf_testcase_0.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_1.sh
+++ b/.ci/terraform/wrf_testcase_1.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_10.sh
+++ b/.ci/terraform/wrf_testcase_10.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_11.sh
+++ b/.ci/terraform/wrf_testcase_11.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_12.sh
+++ b/.ci/terraform/wrf_testcase_12.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_13.sh
+++ b/.ci/terraform/wrf_testcase_13.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_14.sh
+++ b/.ci/terraform/wrf_testcase_14.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_15.sh
+++ b/.ci/terraform/wrf_testcase_15.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_16.sh
+++ b/.ci/terraform/wrf_testcase_16.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_17.sh
+++ b/.ci/terraform/wrf_testcase_17.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_18.sh
+++ b/.ci/terraform/wrf_testcase_18.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_19.sh
+++ b/.ci/terraform/wrf_testcase_19.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_2.sh
+++ b/.ci/terraform/wrf_testcase_2.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_20.sh
+++ b/.ci/terraform/wrf_testcase_20.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_21.sh
+++ b/.ci/terraform/wrf_testcase_21.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_22.sh
+++ b/.ci/terraform/wrf_testcase_22.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_23.sh
+++ b/.ci/terraform/wrf_testcase_23.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_24.sh
+++ b/.ci/terraform/wrf_testcase_24.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_25.sh
+++ b/.ci/terraform/wrf_testcase_25.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_26.sh
+++ b/.ci/terraform/wrf_testcase_26.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_27.sh
+++ b/.ci/terraform/wrf_testcase_27.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_28.sh
+++ b/.ci/terraform/wrf_testcase_28.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_29.sh
+++ b/.ci/terraform/wrf_testcase_29.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_3.sh
+++ b/.ci/terraform/wrf_testcase_3.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_30.sh
+++ b/.ci/terraform/wrf_testcase_30.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_31.sh
+++ b/.ci/terraform/wrf_testcase_31.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_32.sh
+++ b/.ci/terraform/wrf_testcase_32.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_33.sh
+++ b/.ci/terraform/wrf_testcase_33.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_34.sh
+++ b/.ci/terraform/wrf_testcase_34.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_35.sh
+++ b/.ci/terraform/wrf_testcase_35.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_36.sh
+++ b/.ci/terraform/wrf_testcase_36.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_37.sh
+++ b/.ci/terraform/wrf_testcase_37.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_38.sh
+++ b/.ci/terraform/wrf_testcase_38.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_39.sh
+++ b/.ci/terraform/wrf_testcase_39.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_4.sh
+++ b/.ci/terraform/wrf_testcase_4.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_40.sh
+++ b/.ci/terraform/wrf_testcase_40.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_41.sh
+++ b/.ci/terraform/wrf_testcase_41.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_42.sh
+++ b/.ci/terraform/wrf_testcase_42.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_43.sh
+++ b/.ci/terraform/wrf_testcase_43.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_44.sh
+++ b/.ci/terraform/wrf_testcase_44.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_45.sh
+++ b/.ci/terraform/wrf_testcase_45.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_46.sh
+++ b/.ci/terraform/wrf_testcase_46.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_47.sh
+++ b/.ci/terraform/wrf_testcase_47.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_48.sh
+++ b/.ci/terraform/wrf_testcase_48.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_49.sh
+++ b/.ci/terraform/wrf_testcase_49.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_5.sh
+++ b/.ci/terraform/wrf_testcase_5.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_50.sh
+++ b/.ci/terraform/wrf_testcase_50.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_51.sh
+++ b/.ci/terraform/wrf_testcase_51.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_52.sh
+++ b/.ci/terraform/wrf_testcase_52.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_53.sh
+++ b/.ci/terraform/wrf_testcase_53.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_54.sh
+++ b/.ci/terraform/wrf_testcase_54.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_55.sh
+++ b/.ci/terraform/wrf_testcase_55.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_56.sh
+++ b/.ci/terraform/wrf_testcase_56.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_57.sh
+++ b/.ci/terraform/wrf_testcase_57.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_58.sh
+++ b/.ci/terraform/wrf_testcase_58.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_59.sh
+++ b/.ci/terraform/wrf_testcase_59.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_6.sh
+++ b/.ci/terraform/wrf_testcase_6.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_60.sh
+++ b/.ci/terraform/wrf_testcase_60.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_7.sh
+++ b/.ci/terraform/wrf_testcase_7.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_8.sh
+++ b/.ci/terraform/wrf_testcase_8.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop

--- a/.ci/terraform/wrf_testcase_9.sh
+++ b/.ci/terraform/wrf_testcase_9.sh
@@ -3,7 +3,7 @@ su - ubuntu << 'EOF'
 wget https://wrf-testcase-staging.s3.amazonaws.com/upload_script.sh
 mkdir /home/ubuntu/wrf-stuff
 cd wrf-stuff/
-git clone --branch regression+feature https://github.com/davegill/wrf-coop.git
+git clone --branch regression+feature https://github.com/wrf-model/wrf-coop.git
 cd wrf-coop/
 sed -e "s^_GIT_URL_^$GIT_URL^" -e "s^_GIT_BRANCH_^$GIT_BRANCH^" Dockerfile-sed > Dockerfile
 csh build.csh /home/ubuntu/wrf-stuff/wrf-coop /home/ubuntu/wrf-stuff/wrf-coop


### PR DESCRIPTION
Updated scripts to pull from the wrf-model repository, instead of davegill. 

M  .ci/terraform/make_NEW_sh.csh
M  .ci/terraform/make_ORIG_sh.csh
M   .ci/terraform/wrf_testcase_X.sh (0-60)